### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ You'll probably have noticed by now that each time the playbook is run, Ansible 
     - create-ami
 
 - hosts: old-ami-build
+  connection: local
   roles:
     - terminate
 ```
@@ -372,6 +373,7 @@ Our AMI is built, so now we'll want to create a new Launch Configuration to desc
     - create-launch-configuration
 
 - hosts: old-ami-build
+  connection: local
   roles:
     - terminate
 ```
@@ -430,6 +432,7 @@ Clients will connect to an Elastic Load Balancer which will distribute incoming 
     - load-balancer
 
 - hosts: old-ami-build
+  connection: local
   roles:
     - terminate
 ```
@@ -499,6 +502,7 @@ We'll create an Auto Scaling Group and configure it to use the Launch Configurat
     - auto-scaling
 
 - hosts: old-ami-build
+  connection: local
   roles:
     - terminate
 ```
@@ -640,6 +644,7 @@ If you have a domain name, or subdomain, set up with AWS Route 53, you can have 
     - dns
 
 - hosts: old-ami-build
+  connection: local
   roles:
     - terminate
 ```


### PR DESCRIPTION
without `connection: local` in ansible v 2.1.2.0 this code won't run.

It appears this might be the case in 1.9 as well, given that at around line 719 `connection: local` is included