### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Modify `/etc/ansible/ansible.cfg` to use that directory as the inventory source:
 ```ini
 # /etc/ansible/ansible.cfg
 inventory = /etc/ansible/inventory
+error_on_undefined_vars = False
 ```
 
 


### PR DESCRIPTION
if error_on_undefined_vars is set to false an auto-scaling group will not be
created. It will error due to undefined variable